### PR TITLE
Relax dependency version constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 redis
-click >=6.7
 semantic_version
+click >=6.7
 PyYAML
 typing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-redis >=2.10.5, <=2.10.6
+redis
 click >=6.7
 semantic_version ==2.6.0
 PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 redis
 click >=6.7
-semantic_version ==2.6.0
+semantic_version
 PyYAML
 typing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 redis
-semantic_version
 click >=6.7
+semantic_version
 PyYAML
 typing

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     license='BSD 2-clause',
     long_description=LONG_DESC,
     packages=find_packages(),
-    install_requires=['redis', 'pyyaml', 'click>=6.7', 'semantic_version==2.6.0', 'typing'],
+    install_requires=['redis', 'pyyaml', 'click>=6.7', 'semantic_version', 'typing'],
     entry_points='''
         [console_scripts]
         ramp=RAMP.ramp:ramp

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     license='BSD 2-clause',
     long_description=LONG_DESC,
     packages=find_packages(),
-    install_requires=['redis<=2.10.6', 'pyyaml', 'click>=6.7', 'semantic_version==2.6.0', 'typing'],
+    install_requires=['redis', 'pyyaml', 'click>=6.7', 'semantic_version==2.6.0', 'typing'],
     entry_points='''
         [console_scripts]
         ramp=RAMP.ramp:ramp


### PR DESCRIPTION
No special features are used, so practically any version should be good.