### PR TITLE
add support for module dependencies

### DIFF
--- a/RAMP/module_metadata.py
+++ b/RAMP/module_metadata.py
@@ -18,6 +18,7 @@ MODULE_SEMANTIC_VERSION = '0.0.1'
 MODULE_COMMANDS = []  # type: List[Dict[str, str]]
 EXCLUDE_COMMANDS = []  # type: List[str]
 MODULE_CAPABILITIES = []  # type: List[Dict[str, str]]
+MODULE_DEPENDENCIES = []  # type: List[Dict[str, str]]
 COMMAND_LINE_ARGS = ""
 MIN_REDIS_VERSION = "4.0"
 MIN_REDIS_PACK_VERSION = "5.2"
@@ -32,6 +33,7 @@ FIELDS = [
     "command_line_args",
     "commands",
     "config_command",
+    "dependencies",
     "description",
     "display_name",
     "email",
@@ -80,6 +82,7 @@ def create_default_metadata(module_path):
         "license": LICENSE,
         "command_line_args": COMMAND_LINE_ARGS,
         "capabilities": MODULE_CAPABILITIES,
+        "dependencies": MODULE_DEPENDENCIES,
         "min_redis_version": MIN_REDIS_VERSION,
         "min_redis_pack_version": MIN_REDIS_PACK_VERSION,
         "sha256": sha256_checksum(module_path),

--- a/RAMP/packer.py
+++ b/RAMP/packer.py
@@ -122,6 +122,15 @@ def package(module, **args):
     if module_name:
         metadata["module_name"] = module_name
 
+    # validate dependencies
+    for dep in metadata["dependencies"]:
+        if len(dep) != 2:
+            raise Exception("error: a dependency should specify both URI and SHA256")
+        if "url" not in dep:
+            raise Exception("error: dependency missing url")
+        if "sha256" not in dep:
+            raise Exception("error: dependency missing sha256")
+
     try:
         p = Popen('git rev-parse HEAD'.split(' '), stdin=PIPE, stdout=PIPE, stderr=PIPE)
         git_sha, err = p.communicate()

--- a/RAMP/ramp.py
+++ b/RAMP/ramp.py
@@ -92,6 +92,7 @@ def unpack(bundle):
 @click.option('--capabilities', '-C', callback=comma_seperated_to_list, help='comma seperated list of module capabilities')
 @click.option('--exclude-commands', '-E', callback=comma_seperated_to_list, help='comma seperated list of exclude commands')
 @click.option('--overide-command', multiple=True, callback=jsons_str_tuple_to_jsons_tuple, help='gets a command json representation and overide it on the module json file')
+@click.option('--dependencies', callback=jsons_str_tuple_to_jsons_tuple, help='list of module dependencies: <uri, sha256>')
 @click.option('--output', '-o', default='module.zip', help='output file name')
 @click.option('--print-filename-only', '-P', is_flag=True, default=False, help="Print package path, but don't generate file")
 @click.option('--verbose', '-v', is_flag=True, default=False, help='verbose mode: print the resulting metadata')

--- a/example.manifest.yml
+++ b/example.manifest.yml
@@ -18,3 +18,4 @@ capabilities:
 exclude_commands:
     - graph.BULK
 overide_command: [{"command_name": "graph.EXPLAIN"}]
+dependencies: [{"url": "https://s3.amazonaws.com/module/dep1.zip", "sha256": "38aaa5ed7a7f0b5c1e3fed37468d0a960d4a26653c6c937244d170414728e2b5"}, {"url": "https://s3.amazonaws.com/module/dep2.zip", "sha256": "0a960d4a26653c6c937244d170414728e2b538aaa5ed7a7f0b5c1e3fed37468d"}]


### PR DESCRIPTION
Module can specify a list of dependencies in the form of:
`[{url:"URL", sha256: "SHA256"}, ...]`
See: `example.manifest.yml`